### PR TITLE
Support HOST environment for dev

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "sls wsgi serve"
+    "dev": "sls wsgi serve --host ${HOST:-localhost}"
   },
   "repository": {
     "type": "git",

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -38,7 +38,7 @@ custom:
     <<: *base
     environment:
       <<: *environment
-      CORS_ORIGIN: 'http://localhost:8080'
+      CORS_ORIGIN: http://${env:HOST, 'localhost'}:8080
   prod:
     <<: *base
     domain: 'api.galpi.io'

--- a/app/config/dev.env.js
+++ b/app/config/dev.env.js
@@ -1,9 +1,12 @@
 'use strict'
+const config = require('../config')
 const merge = require('webpack-merge')
 const prodEnv = require('./prod.env')
 
+const HOST = process.env.HOST
+
 module.exports = merge(prodEnv, {
   NODE_ENV: '"development"',
-  API_BASE_URL: '"http://localhost:5000"',
-  APP_BASE_URL: '"http://localhost:8080"',
+  API_BASE_URL: `"http://${HOST || config.dev.host}:5000"`,
+  APP_BASE_URL: `"http://${HOST || config.dev.host}:8080"`,
 })


### PR DESCRIPTION
Read HOST environment variable across `api` and `app` instead of using hard coded `localhost`. With this, remote access to dev server would be available.

https://github.com/yeonghoey/galpi/issues/13