### PR TITLE
Add GP_DEV_USER for skipping oauth

### DIFF
--- a/api/galpi/blueprints/auth.py
+++ b/api/galpi/blueprints/auth.py
@@ -42,12 +42,12 @@ def exchange():
 @bp.route('/me')
 def me():
     token = session.get('token')
-    if token is None:
+    info = github.validate_token(token)
+    if info is None:
         session.pop('user', None)
         return jsonify({})
     else:
-        info = github.validate_token(token)
-        user = info.get('user', None)
+        user = info.get('user')
         session['user'] = user
         return jsonify(info)
 

--- a/api/galpi/blueprints/root.py
+++ b/api/galpi/blueprints/root.py
@@ -90,16 +90,7 @@ def delete_item(user, path):
 
 
 def me():
-    user = session.get('user')
-    if user is not None:
-        return user
-
-    token = session.get('token')
-    if token is None:
-        return None
-
-    info = validate_token(token)
-    return info.get('user')
+    return session.get('user')
 
 
 def compose(user, path, subs):

--- a/api/galpi/config.py
+++ b/api/galpi/config.py
@@ -16,3 +16,6 @@ CLIENT_ID = environ['CLIENT_ID']
 CLIENT_SECRET = environ['CLIENT_SECRET']
 CORS_ORIGIN = environ['CORS_ORIGIN']
 TABLE_PREFIX = environ['TABLE_PREFIX']
+
+# Dev Configs (Not defined in serverless.yml)
+GP_DEV_USER = environ.get('GP_DEV_USER')

--- a/api/galpi/github.py
+++ b/api/galpi/github.py
@@ -36,7 +36,15 @@ def acquire_token(code):
 
 
 def validate_token(token):
+    if current_app.config['GP_DEV_USER']:
+        return {'user': current_app.config['GP_DEV_USER']}
+
+    # No token
+    if token is None:
+        return None
+
     response = requests.get(auth_url(token), auth=client_auth())
+    # TODO: Return None if there is an error
     json = response.json()
     user = json.get('user', {})
     return {


### PR DESCRIPTION
GitHub OAuth supports only one `redirect_uri` for an OAuth app.
For `dev`, the `redirect_uri` should be set to `http://localhost:5000/auth` for the usual dev environment.

So, when accessing the dev server remotely(like `http://192.168.0.123:5000`), it is impossible to acquire GitHub OAuth token because GitHub OAuth returns an error of the `redirect_uri` mismatch.

So, let the dev server skip OAuth process by providing an environment variable of the desired username.